### PR TITLE
feat: support regexp

### DIFF
--- a/.pkgdep.json
+++ b/.pkgdep.json
@@ -3,6 +3,7 @@
     "github.com/cloverrose/pkgdep/example"
   ],
   "isExcludeTests": true,
+  "enableRegexp": true,
   "Dependencies": {
     "github.com/cloverrose/pkgdep/example/infra": [
       "github.com/cloverrose/pkgdep/example/domain/*"
@@ -13,6 +14,9 @@
     ],
     "github.com/cloverrose/pkgdep/example/application": [
       "github.com/cloverrose/pkgdep/example/service"
+    ],
+    "github.com/cloverrose/pkgdep/example/foundations/(?P<foundationName>[^/]+)/service": [
+      "github.com/cloverrose/pkgdep/example/foundations/{{.foundationName}}/(domain|infra)"
     ]
   }
 }

--- a/example/foundations/payment/domain/domain.go
+++ b/example/foundations/payment/domain/domain.go
@@ -1,0 +1,3 @@
+package domain
+
+type PaymentDomain struct{}

--- a/example/foundations/payment/infra/infra.go
+++ b/example/foundations/payment/infra/infra.go
@@ -1,0 +1,3 @@
+package infra
+
+type PaymentInfra struct{}

--- a/example/foundations/payment/service/service.go
+++ b/example/foundations/payment/service/service.go
@@ -1,0 +1,11 @@
+package service
+
+import (
+	"github.com/cloverrose/pkgdep/example/foundations/payment/domain"
+	"github.com/cloverrose/pkgdep/example/foundations/payment/infra"
+)
+
+type PaymentService struct {
+	d domain.PaymentDomain
+	i infra.PaymentInfra
+}

--- a/example/foundations/reservation/domain/domain.go
+++ b/example/foundations/reservation/domain/domain.go
@@ -1,0 +1,3 @@
+package domain
+
+type ReservationDomain struct{}

--- a/example/foundations/reservation/infra/infra.go
+++ b/example/foundations/reservation/infra/infra.go
@@ -1,0 +1,3 @@
+package infra
+
+type ReservationInfra struct{}

--- a/example/foundations/reservation/service/service.go
+++ b/example/foundations/reservation/service/service.go
@@ -1,0 +1,11 @@
+package service
+
+import (
+	"github.com/cloverrose/pkgdep/example/foundations/reservation/domain"
+	"github.com/cloverrose/pkgdep/example/foundations/reservation/infra"
+)
+
+type ReservationService struct {
+	d domain.ReservationDomain
+	i infra.ReservationInfra
+}

--- a/example/service/addressservice.go
+++ b/example/service/addressservice.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"github.com/cloverrose/pkgdep/example/domain/address"
 	"github.com/cloverrose/pkgdep/example/infra"
 )
 
@@ -9,7 +10,8 @@ type AddressService struct {
 }
 
 func (s *AddressService) UpdateAddress(ID string, zipCode, prefecture string) {
-	a := s.db.GetAddress(ID)
+	var a *address.Address
+	a = s.db.GetAddress(ID)
 	a.ZipCode = zipCode
 	a.Prefecture = prefecture
 	s.db.SaveAddress(a)

--- a/example/service/userservice.go
+++ b/example/service/userservice.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"github.com/cloverrose/pkgdep/example/domain/user"
 	"github.com/cloverrose/pkgdep/example/infra"
 )
 
@@ -9,7 +10,8 @@ type UserService struct {
 }
 
 func (s *UserService) UpdateName(ID int, newName string) {
-	user := s.db.GetUser(ID)
-	user.Name = newName
-	s.db.SaveUser(user)
+	var u *user.User
+	u = s.db.GetUser(ID)
+	u.Name = newName
+	s.db.SaveUser(u)
 }


### PR DESCRIPTION
## What

Support regexp

Syntax follows
- https://pkg.go.dev/regexp/syntax
- https://pkg.go.dev/text/template

## New fields
 - `enableRegexp` bool

## How to use

If `from` (key of `Dependencies`) contains "named & numbered capturing group" and `to` (value of `Dependencies`) contains template (`{{.foo}}`), `from`'s captured strings are used in `to` template.

