### PR TITLE
feat: support yaml input

### DIFF
--- a/.pkgdep.yaml
+++ b/.pkgdep.yaml
@@ -1,3 +1,5 @@
+---
+# Use the same content with json to make code management easy.
 {
   "targetPackagePrefixList": [
     "github.com/cloverrose/pkgdep/example"

--- a/go.mod
+++ b/go.mod
@@ -3,3 +3,5 @@ module github.com/cloverrose/pkgdep
 go 1.23
 
 require golang.org/x/tools v0.20.0
+
+require gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -4,3 +4,7 @@ golang.org/x/sync v0.7.0 h1:YsImfSBoP9QPYL0xyKJPq0gcaJdG3rInoqxTWbfQu9M=
 golang.org/x/sync v0.7.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
 golang.org/x/tools v0.20.0 h1:hz/CVckiOxybQvFw6h7b/q80NTr9IUQb4s1IIzW7KNY=
 golang.org/x/tools v0.20.0/go.mod h1:WvitBU7JJf6A4jOdg4S1tviW9bhUxkgeCui/0JHctQg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
# What
- Support yaml (or yml) file input.
- Fix config file

# Why
Main reason to increase support file format is comment ability.
JSON can't support comment. 

Complex .pkgdep config file, I want to add comments.