### PR TITLE
perf: cache compiled regexp

### DIFF
--- a/pkg/cachedregexp/cachedregexp.go
+++ b/pkg/cachedregexp/cachedregexp.go
@@ -1,0 +1,42 @@
+package cachedregexp
+
+import (
+	"regexp"
+	"sync"
+)
+
+// CachedRegexp is a wrapper around regexp.Compile that caches the compiled regexps.
+type CachedRegexp struct {
+	enabledCache bool
+	data         map[string]*regexp.Regexp
+	mu           sync.RWMutex
+}
+
+// New creates a new CachedRegexp.
+func New(enabledCache bool) *CachedRegexp {
+	return &CachedRegexp{
+		enabledCache: enabledCache,
+		data:         make(map[string]*regexp.Regexp, 64),
+	}
+}
+
+// Compile compiles a regular expression and returns, as a compiled regular expression, the expression and an error, if any.
+func (c *CachedRegexp) Compile(pattern string) (*regexp.Regexp, error) {
+	if !c.enabledCache {
+		return regexp.Compile(pattern)
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if re, ok := c.data[pattern]; ok {
+		return re, nil
+	}
+
+	re, err := regexp.Compile(pattern)
+	if err != nil {
+		return nil, err
+	}
+	c.data[pattern] = re
+	return re, nil
+}

--- a/pkg/cachedregexp/cachedregexp_test.go
+++ b/pkg/cachedregexp/cachedregexp_test.go
@@ -1,0 +1,54 @@
+package cachedregexp
+
+import (
+	"testing"
+)
+
+func Benchmark_CachedRegexp_Compile_disable(b *testing.B) {
+	re := New(false)
+
+	patterns := providePatterns()
+
+	for b.Loop() {
+		for _, pattern := range patterns {
+			_, _ = re.Compile(pattern)
+		}
+	}
+}
+
+func Benchmark_CachedRegexp_Compile_enable(b *testing.B) {
+	re := New(true)
+
+	patterns := providePatterns()
+
+	for b.Loop() {
+		for _, pattern := range patterns {
+			_, _ = re.Compile(pattern)
+		}
+	}
+}
+
+func providePatterns() []string {
+	return []string{
+		// basic patterns
+		"hello",  // simple pattern
+		"^foo$",  // exact match: "foo" only
+		"bar.*",  // prefix match: "bar" starts with
+		".*baz$", // suffix match: "baz" ends with
+
+		// intermediate patterns
+		"^[A-Z][a-z]+$",    // word starting with uppercase
+		"\\d{3}-\\d{4}",    // postal code: 123-4567
+		"[a-z]+(_[a-z]+)*", // snake case variable name
+
+		// advanced patterns
+		"(?P<year>\\d{4})-(?P<month>\\d{2})-(?P<day>\\d{2})", // named capture group: year-month-day
+		"^(?:https?://)?[\\w.-]+\\.[a-z]{2,}$",               // simple URL validation
+		"^(?=.*[A-Z])(?=.*[a-z])(?=.*\\d).{8,}$",             // password requirements: uppercase, lowercase, digit, 8 characters or more
+
+		// special cases
+		"\\\\.",       // escaped dot
+		"[^\\s]+",     // non-space characters
+		"(?i)pattern", // case-insensitive
+	}
+}

--- a/pkgdep.go
+++ b/pkgdep.go
@@ -5,13 +5,14 @@ import (
 	"errors"
 	"flag"
 	"os"
-	"regexp"
 	"strconv"
 	"strings"
 	"text/template"
 
 	"golang.org/x/tools/go/analysis"
 	"gopkg.in/yaml.v3"
+
+	"github.com/cloverrose/pkgdep/pkg/cachedregexp"
 )
 
 const doc = "pkgdep validates if package dependency follows rule"
@@ -29,6 +30,8 @@ var Analyzer = &analysis.Analyzer{
 // Allowed file extension is [.yaml, .yml]
 // e.g. ./.pkgdep.yaml
 var configFile string
+
+var regexpCache = cachedregexp.New(true)
 
 func init() {
 	Analyzer.Flags.StringVar(&configFile, "config", "", "config file path.")
@@ -61,7 +64,7 @@ func (c *Config) isAllowedDependency(from, to string) bool {
 			if err != nil {
 				continue
 			}
-			re, err := regexp.Compile(toPattern)
+			re, err := regexpCache.Compile(toPattern)
 			if err != nil {
 				continue
 			}
@@ -74,7 +77,7 @@ func (c *Config) isAllowedDependency(from, to string) bool {
 }
 
 func matchAndExtract(pattern, text string) (map[string]string, error) {
-	re, err := regexp.Compile(pattern)
+	re, err := regexpCache.Compile(pattern)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
regular expressions are enabled by default and are now cached to improve performance.