### PR TITLE
feat: use ordered map

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ See [.pkgdep.yaml](./.pkgdep.yaml) as example.
 
 We can use regexp.
 
+**Detailed Information**
+
+`dependencies` is unmarshalled into an ordered map. Package dependencies are validated in order, starting from the first entry.
+
 ### 2. Run
 
 #### A. Use as go vet tool

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.24
 
 require (
 	github.com/golangci/plugin-module-register v0.1.1
+	github.com/google/go-cmp v0.6.0
 	golang.org/x/tools v0.31.0
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/pkg/orderedmap/orderedmap.go
+++ b/pkg/orderedmap/orderedmap.go
@@ -1,0 +1,81 @@
+package orderedmap
+
+import (
+	"fmt"
+	"iter"
+
+	"gopkg.in/yaml.v3"
+)
+
+// OrderedMap keeps the order of keys and values.
+// This is developed for dependencies value.
+type OrderedMap struct {
+	keys   []string
+	values map[string][]string
+}
+
+// New creates a new OrderedMap.
+func New() *OrderedMap {
+	return &OrderedMap{
+		keys:   make([]string, 0),
+		values: make(map[string][]string),
+	}
+}
+
+// Iter returns an iterator over the OrderedMap.
+func (om *OrderedMap) Iter() iter.Seq2[string, []string] {
+	return func(yield func(string, []string) bool) {
+		for _, key := range om.keys {
+			if !yield(key, om.values[key]) {
+				break
+			}
+		}
+	}
+}
+
+// UnmarshalYAML implements the yaml.Unmarshaler interface.
+func (om *OrderedMap) UnmarshalYAML(value *yaml.Node) error {
+	*om = *New()
+
+	// If the document node, process the content.
+	if value.Kind == yaml.DocumentNode && len(value.Content) > 0 {
+		value = value.Content[0]
+	}
+
+	// If the value is not a mapping node, return an error.
+	if value.Kind != yaml.MappingNode {
+		return fmt.Errorf("value is not mapping node")
+	}
+
+	// Process the key and value pairs.
+	for i := 0; i < len(value.Content); i += 2 {
+		keyNode := value.Content[i]
+		valueNode := value.Content[i+1]
+
+		if keyNode.Kind != yaml.ScalarNode {
+			return fmt.Errorf("key is not scalar node")
+		}
+		if valueNode.Kind != yaml.SequenceNode {
+			return fmt.Errorf("value is not sequence node")
+		}
+
+		key := keyNode.Value
+		var parsedValue []string
+		if err := valueNode.Decode(&parsedValue); err != nil {
+			return err
+		}
+
+		om.set(key, parsedValue)
+	}
+
+	return nil
+}
+
+// set adds a key and value to the OrderedMap.
+func (om *OrderedMap) set(key string, value []string) {
+	// If the key does not exist, add it.
+	if _, exists := om.values[key]; !exists {
+		om.keys = append(om.keys, key)
+	}
+	om.values[key] = value
+}

--- a/pkg/orderedmap/orderedmap_test.go
+++ b/pkg/orderedmap/orderedmap_test.go
@@ -1,0 +1,76 @@
+package orderedmap
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestOrderedMap_Iter(t *testing.T) {
+	t.Parallel()
+	type fields struct {
+		Keys   []string
+		Values map[string][]string
+	}
+	type pair struct {
+		Key   string
+		Value []string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   []pair
+	}{
+		{
+			name: "nil",
+			fields: fields{
+				Keys:   nil,
+				Values: nil,
+			},
+			want: nil,
+		},
+		{
+			name: "empty",
+			fields: fields{
+				Keys:   []string{},
+				Values: map[string][]string{},
+			},
+			want: nil,
+		},
+		{
+			name: "one",
+			fields: fields{
+				Keys:   []string{"a"},
+				Values: map[string][]string{"a": {"1", "2", "3"}},
+			},
+			want: []pair{{Key: "a", Value: []string{"1", "2", "3"}}},
+		},
+		{
+			name: "two",
+			fields: fields{
+				Keys:   []string{"b", "a"},
+				Values: map[string][]string{"a": {"1", "2", "3"}, "b": {"4", "5", "6"}},
+			},
+			want: []pair{
+				{Key: "b", Value: []string{"4", "5", "6"}},
+				{Key: "a", Value: []string{"1", "2", "3"}},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			om := &OrderedMap{
+				keys:   tt.fields.Keys,
+				values: tt.fields.Values,
+			}
+			var got []pair
+			for k, v := range om.Iter() {
+				got = append(got, pair{Key: k, Value: v})
+			}
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("OrderedMap.Iter() (-want,+got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/pkgdep.go
+++ b/pkgdep.go
@@ -13,6 +13,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/cloverrose/pkgdep/pkg/cachedregexp"
+	"github.com/cloverrose/pkgdep/pkg/orderedmap"
 )
 
 const doc = "pkgdep validates if package dependency follows rule"
@@ -38,10 +39,10 @@ func init() {
 }
 
 type Config struct {
-	TargetPackagePrefixList []string            `yaml:"targetPackagePrefixList"`
-	IsExcludeTests          bool                `yaml:"isExcludeTests"`
-	EnableRegexp            bool                `yaml:"enableRegexp"`
-	Dependencies            map[string][]string `yaml:"dependencies"`
+	TargetPackagePrefixList []string              `yaml:"targetPackagePrefixList"`
+	IsExcludeTests          bool                  `yaml:"isExcludeTests"`
+	EnableRegexp            bool                  `yaml:"enableRegexp"`
+	Dependencies            orderedmap.OrderedMap `yaml:"dependencies"`
 }
 
 func (c *Config) isTargetPackage(pkg string) bool {
@@ -54,7 +55,7 @@ func (c *Config) isTargetPackage(pkg string) bool {
 }
 
 func (c *Config) isAllowedDependency(from, to string) bool {
-	for fromPattern, toTemplateStrings := range c.Dependencies {
+	for fromPattern, toTemplateStrings := range c.Dependencies.Iter() {
 		data, err := matchAndExtract(fromPattern, from)
 		if err != nil {
 			continue


### PR DESCRIPTION
`dependencies` is unmarshalled into an ordered map. Package dependencies are validated in order, starting from the first entry.