### PR TITLE
feat: support log

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,23 @@
 
 `pkgdep` checks if package dependency follows rule.
 
-## Config
+## Options
 
-`pkgdep` requires you to specify a configuration file using the `config` option.
+- `config` (required)
+  - Path to the configuration file (e.g. `.pkgdep.yaml`)
+  - Supported file extensions: `.yaml`, `.yml`
+- `log.level` (optional)
+  - Controls logging verbosity
+  - Valid values: `DEBUG`, `INFO`, `WARN`, `ERROR`
+  - Default: `INFO`
+- `log.file` (optional)
+  - Path to write log output
+  - If unspecified, logs to stdout
+  - Note: When using with golangci-lint, a log file must be specified since stdout is captured
+- `log.format` (optional)
+  - Controls log output format
+  - Valid values: `json`, `text`
+  - Default: `json`
 
 You can configure via commandline option or golangci setting.
 
@@ -60,8 +74,8 @@ name: custom-golangci-lint
 destination: bin
 plugins:
   - module: 'github.com/cloverrose/pkgdep'
-    import: 'github.com/cloverrose/mockguard'
-    version: v0.4.0
+    import: 'github.com/cloverrose/pkgdep'
+    version: v0.4.3
 ```
 
 `.golangci.yml`
@@ -76,4 +90,8 @@ linters-settings:
       description: pkgdep validates if package dependency follows rule.
       settings:
         config: "./.pkgdep.yaml"
+        log:
+          level: "INFO"
+          file: "./log.txt"
+          format: "json"
 ```

--- a/golangci_plugin.go
+++ b/golangci_plugin.go
@@ -3,6 +3,8 @@ package pkgdep
 import (
 	"github.com/golangci/plugin-module-register/register"
 	"golang.org/x/tools/go/analysis"
+
+	"github.com/cloverrose/pkgdep/pkg/log"
 )
 
 func init() {
@@ -25,6 +27,7 @@ func newPlugin(conf any) (register.LinterPlugin, error) {
 
 type settings struct {
 	Config string
+	Log    log.Config
 }
 
 type plugin struct {
@@ -34,6 +37,15 @@ type plugin struct {
 func (p *plugin) BuildAnalyzers() ([]*analysis.Analyzer, error) {
 	if p.settings.Config != "" {
 		configFile = p.settings.Config
+	}
+	if p.settings.Log.Level != "" {
+		logConfig.Level = p.settings.Log.Level
+	}
+	if p.settings.Log.File != "" {
+		logConfig.File = p.settings.Log.File
+	}
+	if p.settings.Log.Format != "" {
+		logConfig.Format = p.settings.Log.Format
 	}
 	return []*analysis.Analyzer{
 		Analyzer,

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -1,0 +1,64 @@
+package log
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"strings"
+)
+
+// Config is logging configuration.
+type Config struct {
+	Level  string // "debug", "info", "warn", "error"
+	File   string // file name to write log
+	Format string // "json" or "text"
+}
+
+// SetDefault initializes the default logger with the given configuration.
+func SetDefault(cfg Config) (closer func() error, err error) {
+	opts := &slog.HandlerOptions{
+		Level: convertLogLevel(cfg.Level),
+	}
+
+	// default closer
+	closer = func() error { return nil }
+
+	// configure writer
+	writer := os.Stdout
+	if cfg.File != "" {
+		file, err := os.OpenFile(cfg.File, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+		if err != nil {
+			return nil, fmt.Errorf("failed to open log file: %w", err)
+		}
+		writer = file
+		closer = file.Close
+	}
+
+	// configure handler
+	var handler slog.Handler
+	switch strings.ToLower(cfg.Format) {
+	case "text":
+		handler = slog.NewTextHandler(writer, opts)
+	default:
+		handler = slog.NewJSONHandler(writer, opts)
+	}
+
+	// set default logger
+	slog.SetDefault(slog.New(handler))
+	return closer, nil
+}
+
+func convertLogLevel(level string) slog.Level {
+	switch strings.ToLower(level) {
+	case "debug":
+		return slog.LevelDebug
+	case "info":
+		return slog.LevelInfo
+	case "warn":
+		return slog.LevelWarn
+	case "error":
+		return slog.LevelError
+	default:
+		return slog.LevelInfo
+	}
+}

--- a/pkgdep.go
+++ b/pkgdep.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"errors"
 	"flag"
+	"fmt"
+	"log/slog"
 	"os"
 	"strconv"
 	"strings"
@@ -13,6 +15,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/cloverrose/pkgdep/pkg/cachedregexp"
+	"github.com/cloverrose/pkgdep/pkg/log"
 	"github.com/cloverrose/pkgdep/pkg/orderedmap"
 )
 
@@ -22,20 +25,48 @@ const doc = "pkgdep validates if package dependency follows rule"
 var Analyzer = &analysis.Analyzer{
 	Name:     "pkgdep",
 	Doc:      doc,
-	Run:      run,
+	Run:      setupAndRun,
 	Requires: []*analysis.Analyzer{},
 	Flags:    *flag.NewFlagSet("pkgdep", flag.ExitOnError),
 }
 
-// configFile is file path to pkgdep config file.
-// Allowed file extension is [.yaml, .yml]
-// e.g. ./.pkgdep.yaml
-var configFile string
+// options
+var (
+	// configFile is file path to pkgdep config file.
+	// Allowed file extension is [.yaml, .yml]
+	// e.g. ./.pkgdep.yaml
+	configFile string
+
+	// log related configuration.
+	logConfig = log.Config{
+		Level:  "INFO",
+		File:   "",
+		Format: "json",
+	}
+)
 
 var regexpCache = cachedregexp.New(true)
 
 func init() {
 	Analyzer.Flags.StringVar(&configFile, "config", "", "config file path.")
+	Analyzer.Flags.StringVar(&logConfig.Level, "log.level", logConfig.Level, "logging level. debug, info, warn, error")
+	Analyzer.Flags.StringVar(&logConfig.File, "log.file", logConfig.File, "log file path.")
+	Analyzer.Flags.StringVar(&logConfig.Format, "log.format", logConfig.Format, "logging format. json or text")
+}
+
+func setupAndRun(pass *analysis.Pass) (any, error) {
+	closer, err := log.SetDefault(logConfig)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if err := closer(); err != nil {
+			fmt.Println(err)
+		}
+	}()
+	slog.Debug("Starting pkgdep analyzer...")
+
+	return run(pass)
 }
 
 type Config struct {


### PR DESCRIPTION
Support both stdout and file.

Note: When using with golangci-lint, a log file must be specified since stdout is captured