### PR TITLE
feat(globalData): support globalData to extract repetitive pattern and enable defining rule explicitly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,11 @@ test:
 	# @go test $(args) -race -cover ./...
 	@go test $(args) ./...
 
+.PHONY: e2e-test
+e2e-test: build
+e2e-test:
+	go vet -vettool=$(PWD)/bin/pkgdep -pkgdep.config=$(PWD)/.pkgdep.yaml ./...
+
 # build creates the binaries.
 .PHONY: build
 build:

--- a/README.md
+++ b/README.md
@@ -55,6 +55,32 @@ We can use regexp.
 
 `dependencies` is unmarshalled into an ordered map. Package dependencies are validated in order, starting from the first entry.
 
+**globalData**
+
+pkgdep v0.8.0+ supports `globalData` field in `.pkgdep.yaml`.
+This is helpful when your `.pkgdep.yam` becomes complex and has repetetive patterns.
+
+For example, `application` layer can depend on `domain` and `infra` layer, and `domain` layer can depend on `infra` layer. We can define this relationship without `globalData`.
+
+```yaml
+dependencies:
+  .+/modules/(?P<moduleName>[^/]+)/layers/application$:
+    - .+/modules/{{ .moduleName }}/layers/(domain|infra)
+  .+/modules/(?P<moduleName>[^/]+)/layers/domain$:
+    - .+/modules/{{ .moduleName }}/layers/(infra)
+```
+
+With `globalData` we can define like this.
+
+```yaml
+globalData:
+  application: (domain|infra)
+  domain: (infra)
+dependencies:
+  .+/modules/(?P<moduleName>[^/]+)/layers/(?P<layerName>[^/]+)$:
+    - .+/modules/{{ .moduleName }}/layers/{{ index .globalData  .layerName }}
+```
+
 ### 2. Run
 
 #### A. Use as go vet tool
@@ -80,7 +106,7 @@ destination: bin
 plugins:
   - module: 'github.com/cloverrose/pkgdep'
     import: 'github.com/cloverrose/pkgdep'
-    version: v0.7.2
+    version: v0.8.0
 ```
 
 `.golangci.yml`

--- a/pkg/checker/checker.go
+++ b/pkg/checker/checker.go
@@ -3,6 +3,7 @@ package checker
 import (
 	"bytes"
 	"errors"
+	"strings"
 	"text/template"
 
 	"github.com/cloverrose/pkgdep/pkg/cachedregexp"
@@ -78,5 +79,14 @@ func buildPattern(templateString string, data map[string]string) (string, error)
 		return "", err
 	}
 
-	return result.String(), nil
+	ret := result.String()
+	if strings.Contains(ret, "<no value>") {
+		// text/template missingkey=error option does not affect "index" https://github.com/golang/go/issues/60008
+		// ret is used to match with go package and go package does not contain `<` and `>`.
+		// We can ignore the possibility that user defines template with `<no value>`.
+		// Returning error manually to align non index case.
+		return "", errors.New("missing key")
+	}
+
+	return ret, nil
 }

--- a/pkg/checker/checker.go
+++ b/pkg/checker/checker.go
@@ -12,13 +12,15 @@ import (
 
 type Checker struct {
 	dependencies orderedmap.OrderedMap
+	globalData   map[string]any
 	recorder     recorder
 	regexpCache  *cachedregexp.CachedRegexp
 }
 
-func New(dependencies orderedmap.OrderedMap, recorder recorder) *Checker {
+func New(dependencies orderedmap.OrderedMap, globalData map[string]any, recorder recorder) *Checker {
 	return &Checker{
 		dependencies: dependencies,
+		globalData:   globalData,
 		recorder:     recorder,
 		regexpCache:  cachedregexp.New(true),
 	}
@@ -30,8 +32,9 @@ func (c *Checker) IsAllowedDependency(from, to string) bool {
 		if err != nil {
 			continue
 		}
+		mergedData := mergeGlobalData(data, c.globalData)
 		for _, toTemplateString := range toTemplateStrings {
-			toPattern, err := buildPattern(toTemplateString, data)
+			toPattern, err := buildPattern(toTemplateString, mergedData)
 			if err != nil {
 				continue
 			}
@@ -67,7 +70,7 @@ func (c *Checker) matchAndExtract(pattern, text string) (map[string]string, erro
 	return data, nil
 }
 
-func buildPattern(templateString string, data map[string]string) (string, error) {
+func buildPattern(templateString string, data map[string]any) (string, error) {
 	// By using missingkey=error, if templateString refers a key that is not present in the data.
 	// https://pkg.go.dev/text/template#Template.Option
 	tmpl, err := template.New("example").Option("missingkey=error").Parse(templateString)
@@ -89,4 +92,14 @@ func buildPattern(templateString string, data map[string]string) (string, error)
 	}
 
 	return ret, nil
+}
+
+func mergeGlobalData(data map[string]string, globalData map[string]any) map[string]any {
+	merged := make(map[string]any, len(data)+1)
+	for k, v := range data {
+		merged[k] = v
+	}
+
+	merged["globalData"] = globalData
+	return merged
 }

--- a/pkg/checker/checker_test.go
+++ b/pkg/checker/checker_test.go
@@ -30,11 +30,50 @@ func TestChecker_IsAllowedDependency(t *testing.T) {
 			om.Set(`^(?P<ax>a+)(?P<bx>b+)(?P<cx>c+)$`, []string{`^{{ .ax }}/{{ .bx }}/{{ .cx }}$`})
 			return *om
 		}
+
+		globalDataDep = func() orderedmap.OrderedMap {
+			om := orderedmap.New()
+			om.Set(`^(?P<moduleName>(a|b|c))$`, []string{
+				`^{{ index .globalData .moduleName }}$`,
+				`^{{ index .globalData "module" .moduleName }}$`,
+			})
+			return *om
+		}
+
+		complexGlobalDataDep = func() orderedmap.OrderedMap {
+			om := orderedmap.New()
+			om.Set(`^(?P<moduleName>[^/]+)/(?P<layerName>[^/]+)$`, []string{
+				`^{{ .moduleName }}/{{ index .globalData .moduleName .layerName }}$`,
+			})
+			return *om
+		}
+
+		complexGlobalData = func() map[string]any {
+			return map[string]any{
+				// imagine module a and b have application, domain, infra layer.
+				"a": map[string]any{
+					"infra":       "(infra)",
+					"domain":      "(domain|infra)",
+					"application": "(application|domain|infra)",
+				},
+				"b": map[string]any{
+					"infra":       "(infra)",
+					"domain":      "(domain|infra)",
+					"application": "(application|domain|infra)",
+				},
+				// and module c has only application and infra layer.
+				"c": map[string]any{
+					"infra":       "(infra)",
+					"application": "(application|infra)",
+				},
+			}
+		}
 	)
 
 	tests := []struct {
 		name         string
 		dependencies func() orderedmap.OrderedMap
+		globalData   map[string]any
 		recorder     func(ctrl *gomock.Controller) recorder
 		from         string
 		to           string
@@ -144,11 +183,95 @@ func TestChecker_IsAllowedDependency(t *testing.T) {
 			to:   "foo",
 			want: false,
 		},
+		{
+			name:         "globalData match",
+			dependencies: globalDataDep,
+			globalData: map[string]any{
+				"a": "(a|b|c)",
+				"b": "(b|c)",
+				"c": "(c)",
+			},
+			recorder: func(ctrl *gomock.Controller) recorder {
+				m := NewMockrecorder(ctrl)
+				m.EXPECT().RecordUsage(`^(?P<moduleName>(a|b|c))$`, `^{{ index .globalData .moduleName }}$`)
+				return m
+			},
+			from: "a",
+			to:   "b",
+			want: true,
+		},
+		{
+			name:         "globalData nested static key match",
+			dependencies: globalDataDep,
+			globalData: map[string]any{
+				"module": map[string]any{
+					"a": "(a|b|c)",
+					"b": "(b|c)",
+					"c": "(c)",
+				},
+			},
+			recorder: func(ctrl *gomock.Controller) recorder {
+				m := NewMockrecorder(ctrl)
+				m.EXPECT().RecordUsage(`^(?P<moduleName>(a|b|c))$`, `^{{ index .globalData "module" .moduleName }}$`)
+				return m
+			},
+			from: "b",
+			to:   "c",
+			want: true,
+		},
+		{
+			name:         "complex globalData inside module a (match)",
+			dependencies: complexGlobalDataDep,
+			globalData:   complexGlobalData(),
+			recorder: func(ctrl *gomock.Controller) recorder {
+				m := NewMockrecorder(ctrl)
+				m.EXPECT().RecordUsage(gomock.Any(), gomock.Any())
+				return m
+			},
+			from: "a/domain",
+			to:   "a/infra",
+			want: true,
+		},
+		{
+			name:         "complex globalData cross module (unmatch)",
+			dependencies: complexGlobalDataDep,
+			globalData:   complexGlobalData(),
+			recorder: func(ctrl *gomock.Controller) recorder {
+				return NewMockrecorder(ctrl)
+			},
+			from: "a/application",
+			to:   "b/domain",
+			want: false,
+		},
+		{
+			name:         "complex globalData inside module c (match)",
+			dependencies: complexGlobalDataDep,
+			globalData:   complexGlobalData(),
+			recorder: func(ctrl *gomock.Controller) recorder {
+				m := NewMockrecorder(ctrl)
+				m.EXPECT().RecordUsage(gomock.Any(), gomock.Any())
+				return m
+			},
+			from: "c/application",
+			to:   "c/infra",
+			want: true,
+		},
+		{
+			name:         "complex globalData referring invalid layer (unmatch)",
+			dependencies: complexGlobalDataDep,
+			globalData:   complexGlobalData(),
+			recorder: func(ctrl *gomock.Controller) recorder {
+				return NewMockrecorder(ctrl)
+			},
+			from: "c/application",
+			to:   "c/domain", // module c does not have domain layer
+			want: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
-			checker := New(tt.dependencies(), nil, tt.recorder(ctrl))
+			checker := New(tt.dependencies(), tt.globalData, tt.recorder(ctrl))
 			got := checker.IsAllowedDependency(tt.from, tt.to)
 			if diff := cmp.Diff(tt.want, got); diff != "" {
 				t.Errorf("IsAllowedDependency() = (-want +got):\n%s", diff)

--- a/pkg/checker/checker_test.go
+++ b/pkg/checker/checker_test.go
@@ -148,7 +148,7 @@ func TestChecker_IsAllowedDependency(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
-			checker := New(tt.dependencies(), tt.recorder(ctrl))
+			checker := New(tt.dependencies(), nil, tt.recorder(ctrl))
 			got := checker.IsAllowedDependency(tt.from, tt.to)
 			if diff := cmp.Diff(tt.want, got); diff != "" {
 				t.Errorf("IsAllowedDependency() = (-want +got):\n%s", diff)

--- a/pkgdep.go
+++ b/pkgdep.go
@@ -85,6 +85,7 @@ type Config struct {
 	IsExcludeTests          bool                  `yaml:"isExcludeTests"`
 	EnableRegexp            bool                  `yaml:"enableRegexp"`
 	Dependencies            orderedmap.OrderedMap `yaml:"dependencies"`
+	GlobalData              map[string]any        `yaml:"globalData"`
 }
 
 func (c *Config) isTargetPackage(pkg string) bool {
@@ -133,7 +134,7 @@ func run(pass *analysis.Pass) (any, error) {
 		return nil, err
 	}
 
-	checkerInstance := checker.New(cfg.Dependencies, nil, inspectorInstance)
+	checkerInstance := checker.New(cfg.Dependencies, cfg.GlobalData, inspectorInstance)
 
 	fromPackage := pass.Pkg.Path()
 	if !cfg.isTargetPackage(fromPackage) {

--- a/pkgdep.go
+++ b/pkgdep.go
@@ -133,7 +133,7 @@ func run(pass *analysis.Pass) (any, error) {
 		return nil, err
 	}
 
-	checkerInstance := checker.New(cfg.Dependencies, inspectorInstance)
+	checkerInstance := checker.New(cfg.Dependencies, nil, inspectorInstance)
 
 	fromPackage := pass.Pkg.Path()
 	if !cfg.isTargetPackage(fromPackage) {


### PR DESCRIPTION
New `.pkgdep.yaml` config field `globalData` is added.

This is especially helpful if you have complex `.pkgdep.yaml`